### PR TITLE
Added Unit Tests for AvatarGroup

### DIFF
--- a/src/__tests__/unit/components/AvatarGroup.test.tsx
+++ b/src/__tests__/unit/components/AvatarGroup.test.tsx
@@ -1,66 +1,64 @@
-import { cleanup, render, screen } from '@testing-library/react'
-import { afterEach, describe, expect, it } from 'vitest'
+import { cleanup, render, screen } from "@testing-library/react"
+import { afterEach, describe, expect, it } from "vitest"
 
-import { AvatarGroup, TProfile } from '@/components/avatar-group'
+import { AvatarGroup, TProfile } from "@/components/avatar-group"
 
 // Automatically unmount and cleanup DOM after each test
 afterEach(() => {
-  cleanup()
+    cleanup()
 })
 
-describe('AvatarGroup Component', () => {
-  const mockProfiles: TProfile[] = [
-    { name: 'Sunil Kumar', profilePicture: '/path/to/sunil.jpg' },
-    { name: 'Yash Raj', profilePicture: '/path/to/yash.jpg' },
-    { name: 'Prakash', profilePicture: '/path/to/prakash.jpg' },
-    { name: 'Tejas', profilePicture: '/path/to/tejas.jpg' }
-  ]
+describe("AvatarGroup Component", () => {
+    const mockProfiles: TProfile[] = [
+        { name: "Sunil Kumar", profilePicture: "/path/to/sunil.jpg" },
+        { name: "Yash Raj", profilePicture: "/path/to/yash.jpg" },
+        { name: "Prakash", profilePicture: "/path/to/prakash.jpg" },
+        { name: "Tejas", profilePicture: "/path/to/tejas.jpg" },
+    ]
 
-  it('displays all avatars when 3 or fewer profiles are provided', () => {
-    const profiles = mockProfiles.slice(0, 3)
-    render(<AvatarGroup profiles={profiles} />)
+    it("displays all avatars when 3 or fewer profiles are provided", () => {
+        const profiles = mockProfiles.slice(0, 3)
+        render(<AvatarGroup profiles={profiles} />)
 
-    const avatarImages = screen.getAllByRole('img')
-    expect(avatarImages).toHaveLength(3)
+        const avatarImages = screen.getAllByRole("img")
+        expect(avatarImages).toHaveLength(3)
 
-    const countIndicator = screen.queryByText(/\+\d+/)
-    expect(countIndicator).toBeNull()
-  })
-
-  it('displays only 3 avatars when more than 3 profiles are provided', () => {
-    render(<AvatarGroup profiles={mockProfiles} />)
-    const avatarImages = screen.getAllByRole('img')
-    expect(avatarImages).toHaveLength(3)
-  })
-
-  it('displays the correct count indicator when more than 3 profiles are provided', () => {
-    render(<AvatarGroup profiles={mockProfiles} />)
-
-    const remainingCount = mockProfiles.length - 3
-    const countIndicator = screen.getByText(`+${remainingCount}`)
-    expect(countIndicator).toBeDefined()
-  })
-
-  it('applies the correct z-index to avatar containers', () => {
-    render(<AvatarGroup profiles={mockProfiles} />)
-    const avatarContainers = screen.getAllByRole('img')
-    
-    avatarContainers.forEach((container, index) => {
-	  const parentContainer = container?.parentElement?.parentElement;
-      expect(parentContainer?.style.zIndex).toBe(`${30 - index}`)
+        const countIndicator = screen.queryByText(/\+\d+/)
+        expect(countIndicator).toBeNull()
     })
-  })
 
-  it('renders nothing when the profiles array is empty', () => {
-    render(<AvatarGroup profiles={[]} />)
-	
-	const avatars = screen.queryAllByRole('img')
-  	expect(avatars).toHaveLength(0)
+    it("displays only 3 avatars when more than 3 profiles are provided", () => {
+        render(<AvatarGroup profiles={mockProfiles} />)
+        const avatarImages = screen.getAllByRole("img")
+        expect(avatarImages).toHaveLength(3)
+    })
 
-  	// Check that no count indicator (e.g., "+X") is rendered
-  	const countIndicator = screen.queryByText(/\+\d+/)
- 	expect(countIndicator).toBeNull()
+    it("displays the correct count indicator when more than 3 profiles are provided", () => {
+        render(<AvatarGroup profiles={mockProfiles} />)
 
-  })
-  
+        const remainingCount = mockProfiles.length - 3
+        const countIndicator = screen.getByText(`+${remainingCount}`)
+        expect(countIndicator).toBeDefined()
+    })
+
+    it("applies the correct z-index to avatar containers", () => {
+        render(<AvatarGroup profiles={mockProfiles} />)
+        const avatarContainers = screen.getAllByRole("img")
+
+        avatarContainers.forEach((container, index) => {
+            const parentContainer = container?.parentElement?.parentElement
+            expect(parentContainer?.style.zIndex).toBe(`${30 - index}`)
+        })
+    })
+
+    it("renders nothing when the profiles array is empty", () => {
+        render(<AvatarGroup profiles={[]} />)
+
+        const avatars = screen.queryAllByRole("img")
+        expect(avatars).toHaveLength(0)
+
+        // Check that no count indicator (e.g., "+X") is rendered
+        const countIndicator = screen.queryByText(/\+\d+/)
+        expect(countIndicator).toBeNull()
+    })
 })

--- a/src/__tests__/unit/components/AvatarGroup.test.tsx
+++ b/src/__tests__/unit/components/AvatarGroup.test.tsx
@@ -1,0 +1,66 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { AvatarGroup, TProfile } from '@/components/avatar-group'
+
+// Automatically unmount and cleanup DOM after each test
+afterEach(() => {
+  cleanup()
+})
+
+describe('AvatarGroup Component', () => {
+  const mockProfiles: TProfile[] = [
+    { name: 'Sunil Kumar', profilePicture: '/path/to/sunil.jpg' },
+    { name: 'Yash Raj', profilePicture: '/path/to/yash.jpg' },
+    { name: 'Prakash', profilePicture: '/path/to/prakash.jpg' },
+    { name: 'Tejas', profilePicture: '/path/to/tejas.jpg' }
+  ]
+
+  it('displays all avatars when 3 or fewer profiles are provided', () => {
+    const profiles = mockProfiles.slice(0, 3)
+    render(<AvatarGroup profiles={profiles} />)
+
+    const avatarImages = screen.getAllByRole('img')
+    expect(avatarImages).toHaveLength(3)
+
+    const countIndicator = screen.queryByText(/\+\d+/)
+    expect(countIndicator).toBeNull()
+  })
+
+  it('displays only 3 avatars when more than 3 profiles are provided', () => {
+    render(<AvatarGroup profiles={mockProfiles} />)
+    const avatarImages = screen.getAllByRole('img')
+    expect(avatarImages).toHaveLength(3)
+  })
+
+  it('displays the correct count indicator when more than 3 profiles are provided', () => {
+    render(<AvatarGroup profiles={mockProfiles} />)
+
+    const remainingCount = mockProfiles.length - 3
+    const countIndicator = screen.getByText(`+${remainingCount}`)
+    expect(countIndicator).toBeDefined()
+  })
+
+  it('applies the correct z-index to avatar containers', () => {
+    render(<AvatarGroup profiles={mockProfiles} />)
+    const avatarContainers = screen.getAllByRole('img')
+    
+    avatarContainers.forEach((container, index) => {
+	  const parentContainer = container?.parentElement?.parentElement;
+      expect(parentContainer?.style.zIndex).toBe(`${30 - index}`)
+    })
+  })
+
+  it('renders nothing when the profiles array is empty', () => {
+    render(<AvatarGroup profiles={[]} />)
+	
+	const avatars = screen.queryAllByRole('img')
+  	expect(avatars).toHaveLength(0)
+
+  	// Check that no count indicator (e.g., "+X") is rendered
+  	const countIndicator = screen.queryByText(/\+\d+/)
+ 	expect(countIndicator).toBeNull()
+
+  })
+  
+})


### PR DESCRIPTION
<!-- Date Here in dd mmm yyyy-->
## Date: 23rd September, 2024 
<!--Developer Name Here-->
## Developer Name: Sunil Kumar

---

## Issue Ticket Number
<!--Issue ticket this PR closes-->
#120 
## Description

This PR adds unit tests for the `AvatarGroup` component, covering the following scenarios:

- **Avatar Rendering**: Verifies all avatars display when 3 or fewer profiles are provided, and only 3 avatars are shown with a count indicator for additional profiles when more than 3 profiles are given.
  
- **Count Indicator**: Confirms the correct count indicator (e.g., "+X") appears when there are more than 3 profiles.

- **Z-Index Application**: Checks that the correct `z-index` is applied to each avatar container for proper stacking.

- **Empty Profiles Handling**: Ensures no avatars or count indicators are rendered when the profiles array is empty.

### Documentation Updated?

- [ ] Yes
- [x] No

### Under Feature Flag

- [ ] Yes
- [x] No

### Database Changes

- [ ] Yes
- [x] No

### Breaking Changes

- [ ] Yes
- [x] No

### Development Tested?

- [x] Yes
- [ ] No

## Screenshots
<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->

</details>

## Test Coverage
<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->
<img width="668" alt="image" src="https://github.com/user-attachments/assets/230db4e0-644d-43c3-ac74-02483eb27c85">

</details>

## Additional Notes

<!--Any additional notes, considerations or explanations for reviewers-->
